### PR TITLE
Add type annotations and small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ STR# | Array of UTF-8 strings (stored in index.json)
 
 ## Requirements
 
-Python 3.8 or later.
+Python 3.10 or later.
 
 ## How to use
 

--- a/rsrcdump/__main__.py
+++ b/rsrcdump/__main__.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import argparse
+
 from rsrcdump.resfork import unpack_resfork
 from rsrcdump.adf import unpack_adf, ADF_ENTRYNUM_RESOURCEFORK
 from rsrcdump.extract import extract_resource_map

--- a/rsrcdump/adf.py
+++ b/rsrcdump/adf.py
@@ -1,4 +1,4 @@
-from typing import Dict, Final
+from typing import Final
 
 from io import BytesIO
 from struct import pack

--- a/rsrcdump/adf.py
+++ b/rsrcdump/adf.py
@@ -29,7 +29,7 @@ def unpack_adf(adf_data: bytes) -> dict[int, bytes]:
 
     return entries
 
-def pack_adf(adf_entries: Dict[int, bytes]) -> bytes:
+def pack_adf(adf_entries: dict[int, bytes]) -> bytes:
     stream = BytesIO()
     stream.write(pack(">LL16xH", ADF_MAGIC, ADF_VERSION, len(adf_entries)))
 

--- a/rsrcdump/adf.py
+++ b/rsrcdump/adf.py
@@ -1,12 +1,15 @@
+from typing import Dict, Final
+
 from io import BytesIO
-from rsrcdump.packutils import Unpacker, WritePlaceholder
 from struct import pack
 
-ADF_MAGIC   = 0x00051607
-ADF_VERSION = 0x00020000
-ADF_ENTRYNUM_RESOURCEFORK = 2
+from rsrcdump.packutils import Unpacker, WritePlaceholder
 
-def unpack_adf(adf_data):
+ADF_MAGIC: Final   = 0x00051607
+ADF_VERSION: Final = 0x00020000
+ADF_ENTRYNUM_RESOURCEFORK: Final = 2
+
+def unpack_adf(adf_data: bytes) -> Dict[int, bytes]:
     u = Unpacker(adf_data)
 
     magic, version, num_entries = u.unpack(">LL16xH")
@@ -16,7 +19,7 @@ def unpack_adf(adf_data):
 
     entry_offsets = []
 
-    for i in range(num_entries):
+    for _ in range(num_entries):
         entry_offsets.append(u.unpack(">LLL"))
 
     entries = {}
@@ -26,7 +29,7 @@ def unpack_adf(adf_data):
 
     return entries
 
-def pack_adf(adf_entries):
+def pack_adf(adf_entries: Dict[int, bytes]) -> bytes:
     stream = BytesIO()
     stream.write(pack(">LL16xH", ADF_MAGIC, ADF_VERSION, len(adf_entries)))
 
@@ -36,7 +39,7 @@ def pack_adf(adf_entries):
         stream.write(pack(">L", entry_num))
         wp_offsets[entry_num] = WritePlaceholder(stream, ">L")
         stream.write(pack(">L", len(entry_data)))
-
+    
     for entry_num, entry_data in adf_entries.items():
         wp_offsets[entry_num].commit(stream.tell())
         stream.write(entry_data)

--- a/rsrcdump/adf.py
+++ b/rsrcdump/adf.py
@@ -9,7 +9,7 @@ ADF_MAGIC: Final   = 0x00051607
 ADF_VERSION: Final = 0x00020000
 ADF_ENTRYNUM_RESOURCEFORK: Final = 2
 
-def unpack_adf(adf_data: bytes) -> Dict[int, bytes]:
+def unpack_adf(adf_data: bytes) -> dict[int, bytes]:
     u = Unpacker(adf_data)
 
     magic, version, num_entries = u.unpack(">LL16xH")

--- a/rsrcdump/extract.py
+++ b/rsrcdump/extract.py
@@ -8,10 +8,10 @@ from rsrcdump.resconverters import converters
 from rsrcdump.textio import sanitize_type_name, sanitize_resource_name
 from rsrcdump.resfork import Resource
 
-def extract_resource_map(res_map: Dict[bytes, Dict[int, Resource]],
+def extract_resource_map(res_map: dict[bytes, dict[int, Resource]],
                          outpath: str,
-                         include_types: List[bytes]=[],
-                         exclude_types: List[bytes]=[],
+                         include_types: list[bytes]=[],
+                         exclude_types: list[bytes]=[],
                          quiet: bool=False) -> None:
     try:
         os.mkdir(outpath)

--- a/rsrcdump/extract.py
+++ b/rsrcdump/extract.py
@@ -18,7 +18,7 @@ def extract_resource_map(res_map: dict[bytes, dict[int, Resource]],
     except FileExistsError:
         pass
 
-    J: Dict[str, Dict[int, Dict[str, Union[int, str]]]] = {}
+    J: dict[str, dict[int, dict[str, Any]]] = {}
     for res_type, res_dir in res_map.items():
         res_type_key = res_type.decode('macroman')
 

--- a/rsrcdump/extract.py
+++ b/rsrcdump/extract.py
@@ -1,16 +1,24 @@
+from typing import Dict, List, Union
+
 import os
 import base64
 import json
+
 from rsrcdump.resconverters import converters
 from rsrcdump.textio import sanitize_type_name, sanitize_resource_name
+from rsrcdump.resfork import Resource
 
-def extract_resource_map(res_map, outpath, include_types=[], exclude_types=[], quiet=False):
+def extract_resource_map(res_map: Dict[bytes, Dict[int, Resource]],
+                         outpath: str,
+                         include_types: List[bytes]=[],
+                         exclude_types: List[bytes]=[],
+                         quiet: bool=False) -> None:
     try:
         os.mkdir(outpath)
     except FileExistsError:
         pass
 
-    J = {}
+    J: Dict[str, Dict[int, Dict[str, Union[int, str]]]] = {}
     for res_type, res_dir in res_map.items():
         res_type_key = res_type.decode('macroman')
 
@@ -38,7 +46,7 @@ def extract_resource_map(res_map, outpath, include_types=[], exclude_types=[], q
             else:
                 obj = res.data
 
-            wrapper = {}
+            wrapper: Dict[str, Union[int, str]] = {}
             
             if res.name:
                 wrapper['name'] = res.name.decode('macroman')
@@ -70,7 +78,7 @@ def extract_resource_map(res_map, outpath, include_types=[], exclude_types=[], q
 
             J[res_type_key][res_id] = wrapper
 
-    with open(outpath + "/index.json", 'w') as file:
+    with open(outpath + "/index.json", 'w', encoding='utf-8') as file:
         file.write(json.dumps(J, indent='\t'))
 
         if not quiet:

--- a/rsrcdump/extract.py
+++ b/rsrcdump/extract.py
@@ -46,7 +46,7 @@ def extract_resource_map(res_map: dict[bytes, dict[int, Resource]],
             else:
                 obj = res.data
 
-            wrapper: Dict[str, Union[int, str]] = {}
+            wrapper: dict[str, Any] = {}
             
             if res.name:
                 wrapper['name'] = res.name.decode('macroman')

--- a/rsrcdump/extract.py
+++ b/rsrcdump/extract.py
@@ -1,5 +1,3 @@
-from typing import Dict, List, Union
-
 import os
 import base64
 import json

--- a/rsrcdump/extract.py
+++ b/rsrcdump/extract.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import os
 import base64
 import json

--- a/rsrcdump/icons.py
+++ b/rsrcdump/icons.py
@@ -1,9 +1,13 @@
+from typing import Callable, List
+
 from io import BytesIO
-from rsrcdump.packutils import Unpacker
-from rsrcdump.palettes import clut4, clut8
 from struct import pack
 
-def convert_icon_to_bgra(bw_mask, width, height, get_pixel):
+from rsrcdump.packutils import Unpacker
+from rsrcdump.palettes import clut4, clut8
+
+def convert_icon_to_bgra(bw_mask: bytes, width: int, height: int,
+                         get_pixel: Callable[[int, int], int]) -> bytes:
     icon = BytesIO()
     u_mask = Unpacker(bw_mask)
 
@@ -26,22 +30,25 @@ def convert_icon_to_bgra(bw_mask, width, height, get_pixel):
 
     return icon.getvalue()
 
-def convert_8bit_icon_to_bgra(color_icon, bw_mask, width, height):
-    def getpixel8(x, y):
-        pixel = color_icon[y * width + x]
+def convert_8bit_icon_to_bgra(color_icon: bytes, bw_mask: bytes,
+                              width: int, height: int) -> bytes:
+    def getpixel8(x: int, y: int) -> int:
+        pixel: int = color_icon[y * width + x]
         return clut8[pixel]
     return convert_icon_to_bgra(bw_mask, width, height, getpixel8)
 
-def convert_4bit_icon_to_bgra(color_icon, bw_mask, width, height):
-    def getpixel4(x, y):
-        pixel = color_icon[y * (width>>1) + (x>>1)]
+def convert_4bit_icon_to_bgra(color_icon: bytes, bw_mask: bytes,
+                              width: int, height: int) -> bytes:
+    def getpixel4(x: int, y: int) -> int:
+        pixel: int = color_icon[y * (width>>1) + (x>>1)]
         if 0 == (x & 1):
             pixel >>= 4
         pixel &= 0x0F
         return clut4[pixel]
     return convert_icon_to_bgra(bw_mask, width, height, getpixel4)
 
-def convert_1bit_icon_to_bgra(bw_data, bw_mask, width, height):
+def convert_1bit_icon_to_bgra(bw_data: bytes, bw_mask: bytes,
+                              width: int, height: int) -> bytes:
     icon = BytesIO()
     u_data = Unpacker(bw_data)
     u_mask = Unpacker(bw_mask)

--- a/rsrcdump/icons.py
+++ b/rsrcdump/icons.py
@@ -1,4 +1,4 @@
-from typing import Callable, List
+from typing import Callable
 
 from io import BytesIO
 from struct import pack

--- a/rsrcdump/packutils.py
+++ b/rsrcdump/packutils.py
@@ -23,7 +23,7 @@ class Unpacker:
         self.offset += size
         return data_slice
 
-    def unpack_pstr(self, decode: bool=True) -> Union[str, bytes]:
+    def unpack_pstr(self, decode: bool=True) -> str | bytes:
         length, = self.unpack(">B")
         binary_pstr = self.read(length)
         if decode:

--- a/rsrcdump/packutils.py
+++ b/rsrcdump/packutils.py
@@ -8,7 +8,7 @@ class Unpacker:
         self.data = data
         self.offset = offset
 
-    def unpack(self, fmt: str) -> Tuple:
+    def unpack(self, fmt: str) -> tuple:
         record_length = struct.calcsize(fmt)
         fields = struct.unpack_from(fmt, self.data, self.offset)
         self.offset += record_length

--- a/rsrcdump/packutils.py
+++ b/rsrcdump/packutils.py
@@ -1,5 +1,3 @@
-from typing import Tuple, Union
-
 from io import BytesIO
 import struct
 

--- a/rsrcdump/packutils.py
+++ b/rsrcdump/packutils.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from io import BytesIO
 import struct
 

--- a/rsrcdump/packutils.py
+++ b/rsrcdump/packutils.py
@@ -1,48 +1,50 @@
+from typing import Tuple, Union
+
+from io import BytesIO
 import struct
 
 class Unpacker:
-    def __init__(self, data, offset=0):
+    def __init__(self, data: bytes, offset: int=0) -> None:
         self.data = data
-        self.offset = 0
-    
-    def unpack(self, fmt):
+        self.offset = offset
+
+    def unpack(self, fmt: str) -> Tuple:
         record_length = struct.calcsize(fmt)
         fields = struct.unpack_from(fmt, self.data, self.offset)
         self.offset += record_length
         return fields
 
-    def seek(self, offset):
+    def seek(self, offset: int) -> None:
         self.offset = offset
 
-    def read(self, size):
+    def read(self, size: int) -> bytes:
         data_slice = self.data[self.offset : self.offset + size]
         assert len(data_slice) == size
         self.offset += size
         return data_slice
 
-    def unpack_pstr(self, decode=True):
+    def unpack_pstr(self, decode: bool=True) -> Union[str, bytes]:
         length, = self.unpack(">B")
         binary_pstr = self.read(length)
         if decode:
             return binary_pstr.decode("macroman")
-        else:
-            return binary_pstr
+        return binary_pstr
 
-    def eof(self):
+    def eof(self) -> bool:
         return self.offset >= len(self.data)
 
-    def remaining(self):
+    def remaining(self) -> int:
         return len(self.data) - self.offset
 
 class WritePlaceholder:
-    def __init__(self, stream, fmt):
+    def __init__(self, stream: BytesIO, fmt: str) -> None:
         self.stream = stream
         self.fmt = fmt
         self.position = self.stream.tell()
         self.stream.write(b'\xCA' * struct.calcsize(fmt))
         self.committed = False
 
-    def commit(self, value):
+    def commit(self, value: Union[int, bytes, str]) -> None:
         assert not self.committed, "Already committed"
         position_backup = self.stream.tell()
         data = struct.pack(self.fmt, value)
@@ -51,11 +53,11 @@ class WritePlaceholder:
         self.stream.seek(position_backup)
         self.committed = True
 
-    def __del__(self):
+    def __del__(self) -> None:
         if not self.committed:
-            print(F"WARNING: WritePlaceholder is being garbage-collected but was not committed")
+            print("WARNING: WritePlaceholder is being garbage-collected but was not committed")
 
-def pack_pstr(text, padding, encoding='macroman'):
+def pack_pstr(text: str, padding: int, encoding: str='macroman') -> bytes:
     bintext = text.encode(encoding)
     buf = struct.pack(">B", len(bintext)) + bintext
     pad_count = (1 + len(bintext)) % padding

--- a/rsrcdump/packutils.py
+++ b/rsrcdump/packutils.py
@@ -44,7 +44,7 @@ class WritePlaceholder:
         self.stream.write(b'\xCA' * struct.calcsize(fmt))
         self.committed = False
 
-    def commit(self, value: Union[int, bytes, str]) -> None:
+    def commit(self, value: Any) -> None:
         assert not self.committed, "Already committed"
         position_backup = self.stream.tell()
         data = struct.pack(self.fmt, value)

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -572,7 +572,7 @@ def convert_ppat_to_image(data: bytes) -> tuple[int, int, bytes]:
     pm = read_bitmap_or_pixmap(u)
     
     if isinstance(pm, Bitmap):
-        raise ValueError('Expected Bitmap from read_bitmap_or_pixmap')
+        raise ValueError('Expected Pixmap from read_bitmap_or_pixmap')
 
     image_data = u.read(pm.pmtable - pat_data)  # pm.pmtable = offset to clut
     palette = read_colortable(u)

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -122,7 +122,7 @@ def unpackbw(u: Unpacker, bm: Bitmap) -> bytes:
                 dst.write(b'\xFF\xFF\xFF\xFF')
     return dst.getvalue()
 
-def unpack0(u: Unpacker, pmh: Pixmap, palette: List[bytes]) -> bytes: # w: int, h: int, rowbytes: bytes, palette: List[bytes]) -> bytes:
+def unpack0(u: Unpacker, pmh: Pixmap, palette: list[bytes]) -> bytes:
     unpacked = bytes(unpack_all_rows(u, ">B", numrows=pmh.frame_h, rowbytes=pmh.rowbytes))
 
     assert len(unpacked) == pmh.rowbytes * pmh.frame_h

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -27,8 +27,8 @@ class Xmap:
         return self.frame_b - self.frame_t
 
     @property
-    def frame_rect(self) -> Tuple[int, int, int, int]:
-        return (self.frame_t, self.frame_l, self.frame_b, self.frame_r)# type: ignore
+    def frame_rect(self) -> tuple[int, int, int, int]:
+        return (self.frame_t, self.frame_l, self.frame_b, self.frame_r)
 
     @property
     def pixelsperrow(self) -> int:

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -588,7 +588,7 @@ def convert_ppat_to_image(data: bytes) -> tuple[int, int, bytes]:
         bgra.write(palette[px])
     return pm.frame_w, pm.frame_h, bgra.getvalue()
 
-def convert_sicn_to_image(data: bytes) -> Tuple[int, int, bytes]:
+def convert_sicn_to_image(data: bytes) -> tuple[int, int, bytes]:
     num_icons = len(data) // 32
     image8 = convert_to_8bit(data, 1)
     bgra = io.BytesIO()

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -69,7 +69,7 @@ class Pixmap(Xmap):
     planebytes: int
     pmtable: int
 
-def rect_dims(rect_tuple: Tuple[int, int, int, int]) -> Tuple[int, int]:
+def rect_dims(rect_tuple: tuple[int, int, int, int]) -> tuple[int, int]:
     t, l, b, r = rect_tuple
     return r-l, b-t
 

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -1,5 +1,3 @@
-from typing import Dict, List, Tuple, Union
-
 from ctypes import ArgumentError
 import io
 from dataclasses import dataclass

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -5,7 +5,6 @@ import struct
 
 from rsrcdump.packutils import Unpacker
 
-
 class PICTError(Exception):
     pass
 
@@ -45,7 +44,7 @@ class Bitmap(Xmap):
     frame_r: int
 
     @property
-    def pixelsize(self) -> int:
+    def pixelsize(self) -> int:# type: ignore
         return 1
 
 @dataclass
@@ -284,7 +283,7 @@ def read_pict_bits(u: Unpacker, opcode: int) -> tuple[tuple[int, int, int, int],
     if opcode in [0x0091, 0x009b]:
         raise PICTError("read_pict_bits unimplemented opcode")
 
-    bgra = read_pixmap_image_data(u, pmh, palette)
+    bgra = read_pixmap_image_data(u, pmh, palette)# type: ignore
 
     if mask:
         out = io.BytesIO()

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -510,7 +510,7 @@ def trim_excess_columns_8bit(raw8: bytes, pm: Xmap) -> bytes:
         out.write(raw8[y*(w+excess) : y*(w+excess) + w])
     return out.getvalue()
 
-def convert_cicn_to_image(data: bytes) -> Tuple[int, int, bytes]:
+def convert_cicn_to_image(data: bytes) -> tuple[int, int, bytes]:
     u = Unpacker(data)
     
     off = u.offset

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -32,7 +32,7 @@ class Xmap:
 
     @property
     def pixelsperrow(self) -> int:
-        return 8 * self.rowbytes // self.pixelsize# type: ignore
+        return 8 * self.rowbytes // self.pixelsize
 
     @property
     def excesscolumns(self) -> int:

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -370,7 +370,7 @@ def get_reserved_opcode_size(k: int) -> int:
     if 0x8000 <= k <= 0x80FF: return 0
     return -1
 
-def convert_pict_to_image(data: bytes) -> Tuple[int, int, bytes]:
+def convert_pict_to_image(data: bytes) -> tuple[int, int, bytes]:
     u = Unpacker(data)
     start_offset = u.offset
 

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -24,7 +24,7 @@ class Xmap:
 
     @property
     def frame_h(self) -> int:
-        return self.frame_b - self.frame_t# type: ignore
+        return self.frame_b - self.frame_t
 
     @property
     def frame_rect(self) -> Tuple[int, int, int, int]:

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -20,7 +20,7 @@ class Xmap:
     frame_r: int
     @property
     def frame_w(self) -> int:
-        return self.frame_r - self.frame_l# type: ignore
+        return self.frame_r - self.frame_l
 
     @property
     def frame_h(self) -> int:

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -555,7 +555,7 @@ def convert_cicn_to_image(data: bytes) -> tuple[int, int, bytes]:
 
     return iconpm.frame_w, iconpm.frame_h, dst.getvalue()
 
-def convert_ppat_to_image(data: bytes) -> Tuple[int, int, bytes]:
+def convert_ppat_to_image(data: bytes) -> tuple[int, int, bytes]:
     # IM:QD page 4-103
     u = Unpacker(data)
 

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -281,7 +281,7 @@ def read_pict_bits(u: Unpacker, opcode: int) -> tuple[tuple[int, int, int, int],
             mask = unpack_maskrgn(maskrgn_bits, mask_w, mask_h)
             #print(binascii.hexlify(maskrgn_bits, ' ', 2))
 
-    if opcode in [0x0091, 0x009b] or palette is None:
+    if opcode in [0x0091, 0x009b]:
         raise PICTError("read_pict_bits unimplemented opcode")
 
     bgra = read_pixmap_image_data(u, pmh, palette)

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -12,8 +12,12 @@ class PICTError(Exception):
     pass
 
 class Xmap:
-    __slots__ = ('frame_r', 'frame_l', 'frame_b', 'frame_t',
-                 'rowbytes', 'pixelsize')
+    rowbytes: int
+    pixelsize: int
+    frame_t: int
+    frame_l: int
+    frame_b: int
+    frame_r: int
     @property
     def frame_w(self) -> int:
         return self.frame_r - self.frame_l# type: ignore

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -183,7 +183,7 @@ def read_bitmap_or_pixmap(u: Unpacker) -> Union[Pixmap, Bitmap]:
         return Pixmap(rowbytes, *u.unpack("> 4h hh i ii hhhh i i 4x"))
     return Bitmap(rowbytes, *u.unpack("> 4h"))
 
-def read_colortable(u: Unpacker) -> List[bytes]:
+def read_colortable(u: Unpacker) -> list[bytes]:
     seed, flags, numcolors = u.unpack(">LHH")
     numcolors += 1
     #print(F"Seed: {seed:08x}", "NColors:", numcolors)

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -175,7 +175,7 @@ def unpack4(u: Unpacker, w: int, h: int, rowbytes: int, numplanes: int) -> bytes
                 dst.write(struct.pack(">BBBB", b,g,r,a))
     return dst.getvalue()
 
-def read_bitmap_or_pixmap(u: Unpacker) -> Union[Pixmap, Bitmap]:
+def read_bitmap_or_pixmap(u: Unpacker) -> Bitmap | Pixmap:
     rowbytes_flag = u.unpack(">H")[0]
     rowbytes = rowbytes_flag & 0x7FFF
     is_pixmap = 0 != (rowbytes_flag & 0x8000)

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -249,7 +249,7 @@ def unpack_maskrgn(mask: bytes, w: int, h: int) -> bytes:
     assert len(buf) == w*h
     return buf
 
-def read_pict_bits(u: Unpacker, opcode: int) -> Tuple[Tuple[int, int, int, int], bytes]:
+def read_pict_bits(u: Unpacker, opcode: int) -> tuple[tuple[int, int, int, int], bytes]:
     direct_bits_opcode = opcode in [0x009A, 0x009B]
     region_opcode = opcode in [0x0091, 0x0099]
 

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -1,31 +1,37 @@
+from typing import Dict, List, Tuple, Union
+
 from ctypes import ArgumentError
 import io
-from rsrcdump.packutils import Unpacker
 from dataclasses import dataclass
 import struct
+
+from rsrcdump.packutils import Unpacker
+
 
 class PICTError(Exception):
     pass
 
 class Xmap:
+    __slots__ = ('frame_r', 'frame_l', 'frame_b', 'frame_t',
+                 'rowbytes', 'pixelsize')
     @property
-    def frame_w(self):
-        return self.frame_r - self.frame_l
+    def frame_w(self) -> int:
+        return self.frame_r - self.frame_l# type: ignore
 
     @property
-    def frame_h(self):
-        return self.frame_b - self.frame_t
+    def frame_h(self) -> int:
+        return self.frame_b - self.frame_t# type: ignore
 
     @property
-    def frame_rect(self):
-        return (self.frame_t, self.frame_l, self.frame_b, self.frame_r)
+    def frame_rect(self) -> Tuple[int, int, int, int]:
+        return (self.frame_t, self.frame_l, self.frame_b, self.frame_r)# type: ignore
 
     @property
-    def pixelsperrow(self):
-        return 8 * self.rowbytes // self.pixelsize
+    def pixelsperrow(self) -> int:
+        return 8 * self.rowbytes // self.pixelsize# type: ignore
 
     @property
-    def excesscolumns(self):
+    def excesscolumns(self) -> int:
         return self.pixelsperrow - self.frame_w
 
 @dataclass
@@ -37,7 +43,7 @@ class Bitmap(Xmap):
     frame_r: int
 
     @property
-    def pixelsize(self):
+    def pixelsize(self) -> int:
         return 1
 
 @dataclass
@@ -59,11 +65,11 @@ class Pixmap(Xmap):
     planebytes: int
     pmtable: int
 
-def rect_dims(rect_tuple):
+def rect_dims(rect_tuple: Tuple[int, int, int, int]) -> Tuple[int, int]:
     t, l, b, r = rect_tuple
     return r-l, b-t
 
-def unpack_bits(slice, packfmt, rowbytes):
+def unpack_bits(slice: bytes, packfmt: str, rowbytes: int) -> List[int]:
     unpacked = []
 
     u = Unpacker(slice)
@@ -78,13 +84,13 @@ def unpack_bits(slice, packfmt, rowbytes):
             unpacked.extend([item] * stride)
         else:  # unpacked data
             stride = flag + 1
-            for k in range(stride):
+            for _ in range(stride):
                 item = u.unpack(packfmt)[0]
                 unpacked.append(item)
 
     return unpacked
 
-def unpack_all_rows(u: Unpacker, packfmt, numrows, rowbytes):
+def unpack_all_rows(u: Unpacker, packfmt: str, numrows: int, rowbytes: int) -> List[int]:
     assert rowbytes >= 8, "data is unpacked if rowbytes < 8; handle this case"
 
     data = []
@@ -98,7 +104,7 @@ def unpack_all_rows(u: Unpacker, packfmt, numrows, rowbytes):
         data.extend(rowpixels)
     return data
 
-def unpackbw(u: Unpacker, bm: Bitmap):
+def unpackbw(u: Unpacker, bm: Bitmap) -> bytes:
     unpacked = unpack_all_rows(u, ">B", numrows=bm.frame_h, rowbytes=bm.rowbytes)
     dst = io.BytesIO()
     for y in range(bm.frame_h):
@@ -112,9 +118,8 @@ def unpackbw(u: Unpacker, bm: Bitmap):
                 dst.write(b'\xFF\xFF\xFF\xFF')
     return dst.getvalue()
 
-def unpack0(u: Unpacker, pmh: Pixmap, palette): # w, h, rowbytes, palette):
-    unpacked = unpack_all_rows(u, ">B", numrows=pmh.frame_h, rowbytes=pmh.rowbytes)
-    unpacked = bytes(unpacked)
+def unpack0(u: Unpacker, pmh: Pixmap, palette: List[bytes]) -> bytes: # w: int, h: int, rowbytes: bytes, palette: List[bytes]) -> bytes:
+    unpacked = bytes(unpack_all_rows(u, ">B", numrows=pmh.frame_h, rowbytes=pmh.rowbytes))
 
     assert len(unpacked) == pmh.rowbytes * pmh.frame_h
 
@@ -129,7 +134,7 @@ def unpack0(u: Unpacker, pmh: Pixmap, palette): # w, h, rowbytes, palette):
     return dst.getvalue()
 
 # Unpack pixel type 3 (16 bits, chunky)
-def unpack3(u: Unpacker, w, h, rowbytes):
+def unpack3(u: Unpacker, w: int, h: int, rowbytes: int) -> bytes:
     unpacked = unpack_all_rows(u, ">H", h, rowbytes)
     if len(unpacked) != w*h:
         raise PICTError("unpack3: unexpected item count")
@@ -143,7 +148,7 @@ def unpack3(u: Unpacker, w, h, rowbytes):
     return dst.getvalue()
 
 # Unpack pixel type 4 (24 or 32 bits, planar)
-def unpack4(u: Unpacker, w, h, rowbytes, numplanes):
+def unpack4(u: Unpacker, w: int, h: int, rowbytes: int, numplanes: int) -> bytes:
     unpacked = unpack_all_rows(u, ">B", h, rowbytes)
     if len(unpacked) != numplanes*w*h:
         raise PICTError("unpack4: unexpected item count")
@@ -166,16 +171,15 @@ def unpack4(u: Unpacker, w, h, rowbytes, numplanes):
                 dst.write(struct.pack(">BBBB", b,g,r,a))
     return dst.getvalue()
 
-def read_bitmap_or_pixmap(u: Unpacker):
+def read_bitmap_or_pixmap(u: Unpacker) -> Union[Pixmap, Bitmap]:
     rowbytes_flag = u.unpack(">H")[0]
     rowbytes = rowbytes_flag & 0x7FFF
     is_pixmap = 0 != (rowbytes_flag & 0x8000)
     if is_pixmap:
         return Pixmap(rowbytes, *u.unpack("> 4h hh i ii hhhh i i 4x"))
-    else:
-        return Bitmap(rowbytes, *u.unpack("> 4h"))
+    return Bitmap(rowbytes, *u.unpack("> 4h"))
 
-def read_colortable(u: Unpacker):
+def read_colortable(u: Unpacker) -> List[bytes]:
     seed, flags, numcolors = u.unpack(">LHH")
     numcolors += 1
     #print(F"Seed: {seed:08x}", "NColors:", numcolors)
@@ -208,7 +212,7 @@ def read_colortable(u: Unpacker):
     
     return palette
 
-def unpack_maskrgn(mask, w, h):
+def unpack_maskrgn(mask: bytes, w: int, h: int) -> bytes:
     out = io.BytesIO()
 
     u = Unpacker(mask)
@@ -241,7 +245,7 @@ def unpack_maskrgn(mask, w, h):
     assert len(buf) == w*h
     return buf
 
-def read_pict_bits(u: Unpacker, opcode):
+def read_pict_bits(u: Unpacker, opcode: int) -> Tuple[Tuple[int, int, int, int], bytes]:
     direct_bits_opcode = opcode in [0x009A, 0x009B]
     region_opcode = opcode in [0x0091, 0x0099]
 
@@ -275,7 +279,7 @@ def read_pict_bits(u: Unpacker, opcode):
             mask = unpack_maskrgn(maskrgn_bits, mask_w, mask_h)
             #print(binascii.hexlify(maskrgn_bits, ' ', 2))
 
-    if opcode in [0x0091, 0x009b]:
+    if opcode in [0x0091, 0x009b] or palette is None:
         raise PICTError("read_pict_bits unimplemented opcode")
 
     bgra = read_pixmap_image_data(u, pmh, palette)
@@ -288,7 +292,7 @@ def read_pict_bits(u: Unpacker, opcode):
 
     return pmh.frame_rect, bgra
 
-def read_pixmap_image_data(u: Unpacker, pmh, palette):
+def read_pixmap_image_data(u: Unpacker, pmh: Union[Bitmap, Pixmap], palette: List[bytes]) -> bytes:
     frame_w, frame_h = pmh.frame_w, pmh.frame_h
     if frame_w < 0 or frame_h < 0:
         raise PICTError(F"illegal canvas dimensions {frame_w} {frame_h}")
@@ -301,8 +305,7 @@ def read_pixmap_image_data(u: Unpacker, pmh, palette):
         return unpack3(u, frame_w, frame_h, pmh.rowbytes)
     elif pmh.packtype == 4:
         return unpack4(u, frame_w, frame_h, pmh.rowbytes, pmh.cmpcount)
-    else:
-        raise PICTError(F"unsupported pack_type {pmh.packtype}")
+    raise PICTError(F"unsupported pack_type {pmh.packtype}")
 
 skip_opcodes = {
     0x0000: (0, "NOP"),
@@ -342,7 +345,7 @@ skip_opcodes = {
     0x007C: (0, "fillSamePoly"),
 }
 
-def get_reserved_opcode_size(k):
+def get_reserved_opcode_size(k: int) -> int:
     if 0x0035 <= k <= 0x0037: return 8
     if 0x003D <= k <= 0x003F: return 0
     if 0x0045 <= k <= 0x0047: return 8
@@ -363,7 +366,7 @@ def get_reserved_opcode_size(k):
     if 0x8000 <= k <= 0x80FF: return 0
     return -1
 
-def convert_pict_to_image(data):
+def convert_pict_to_image(data: bytes) -> Tuple[int, int, bytes]:
     u = Unpacker(data)
     start_offset = u.offset
 
@@ -423,7 +426,7 @@ def convert_pict_to_image(data):
             length, = u.unpack(">L")
             u.read(length)
         elif opcode in [0x00FF]:  # done
-            if not pm:
+            if not pm or not pm_rect:
                 print("!!! exiting PICT without a pixmap")
                 return 0, 0, b''
             pm_w, pm_h = rect_dims(pm_rect)
@@ -461,7 +464,7 @@ def convert_pict_to_image(data):
         else:
             raise PICTError(F"unsupported PICT opcode 0x{opcode:04x}")
 
-def convert_to_8bit(raw, pixelsize):
+def convert_to_8bit(raw: bytes, pixelsize: int) -> bytes:
     if pixelsize == 8:
         return raw
     
@@ -492,7 +495,7 @@ def convert_to_8bit(raw, pixelsize):
 
     return out.getvalue()
 
-def trim_excess_columns_8bit(raw8, pm):
+def trim_excess_columns_8bit(raw8: bytes, pm: Xmap) -> bytes:
     w = pm.frame_w
     h = pm.frame_h
     excess = pm.excesscolumns
@@ -503,7 +506,7 @@ def trim_excess_columns_8bit(raw8, pm):
         out.write(raw8[y*(w+excess) : y*(w+excess) + w])
     return out.getvalue()
 
-def convert_cicn_to_image(data):
+def convert_cicn_to_image(data: bytes) -> Tuple[int, int, bytes]:
     u = Unpacker(data)
     
     off = u.offset
@@ -548,7 +551,7 @@ def convert_cicn_to_image(data):
 
     return iconpm.frame_w, iconpm.frame_h, dst.getvalue()
 
-def convert_ppat_to_image(data):
+def convert_ppat_to_image(data: bytes) -> Tuple[int, int, bytes]:
     # IM:QD page 4-103
     u = Unpacker(data)
 
@@ -565,6 +568,9 @@ def convert_ppat_to_image(data):
 
     u.read(4)  # Skip junk
     pm = read_bitmap_or_pixmap(u)
+    
+    if isinstance(pm, Bitmap):
+        raise ValueError('Expected Bitmap from read_bitmap_or_pixmap')
 
     image_data = u.read(pm.pmtable - pat_data)  # pm.pmtable = offset to clut
     palette = read_colortable(u)
@@ -578,7 +584,7 @@ def convert_ppat_to_image(data):
         bgra.write(palette[px])
     return pm.frame_w, pm.frame_h, bgra.getvalue()
 
-def convert_sicn_to_image(data):
+def convert_sicn_to_image(data: bytes) -> Tuple[int, int, bytes]:
     num_icons = len(data) // 32
     image8 = convert_to_8bit(data, 1)
     bgra = io.BytesIO()

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -73,7 +73,7 @@ def rect_dims(rect_tuple: tuple[int, int, int, int]) -> tuple[int, int]:
     t, l, b, r = rect_tuple
     return r-l, b-t
 
-def unpack_bits(slice: bytes, packfmt: str, rowbytes: int) -> List[int]:
+def unpack_bits(slice: bytes, packfmt: str, rowbytes: int) -> list[int]:
     unpacked = []
 
     u = Unpacker(slice)

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -296,7 +296,7 @@ def read_pict_bits(u: Unpacker, opcode: int) -> tuple[tuple[int, int, int, int],
 
     return pmh.frame_rect, bgra
 
-def read_pixmap_image_data(u: Unpacker, pmh: Union[Bitmap, Pixmap], palette: List[bytes]) -> bytes:
+def read_pixmap_image_data(u: Unpacker, pmh: Bitmap | Pixmap, palette: list[bytes]) -> bytes:
     frame_w, frame_h = pmh.frame_w, pmh.frame_h
     if frame_w < 0 or frame_h < 0:
         raise PICTError(F"illegal canvas dimensions {frame_w} {frame_h}")

--- a/rsrcdump/pict.py
+++ b/rsrcdump/pict.py
@@ -94,7 +94,7 @@ def unpack_bits(slice: bytes, packfmt: str, rowbytes: int) -> list[int]:
 
     return unpacked
 
-def unpack_all_rows(u: Unpacker, packfmt: str, numrows: int, rowbytes: int) -> List[int]:
+def unpack_all_rows(u: Unpacker, packfmt: str, numrows: int, rowbytes: int) -> list[int]:
     assert rowbytes >= 8, "data is unpacked if rowbytes < 8; handle this case"
 
     data = []

--- a/rsrcdump/png.py
+++ b/rsrcdump/png.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 from types import TracebackType
 
 import io

--- a/rsrcdump/png.py
+++ b/rsrcdump/png.py
@@ -1,10 +1,14 @@
+from typing import List, Optional
+from types import TracebackType
+
 import io
 import zlib
 import struct
+
 from rsrcdump.packutils import WritePlaceholder
 
 class PNGChunkWriter:
-    def __init__(self, stream, chunk_type):
+    def __init__(self, stream: io.BytesIO, chunk_type: bytes) -> None:
         assert type(chunk_type) is bytes
         assert len(chunk_type) == 4
         self.stream = stream
@@ -13,21 +17,24 @@ class PNGChunkWriter:
         self.start_of_block = self.stream.tell()
         self.write(chunk_type)
 
-    def __enter__(self):
+    def __enter__(self) -> 'PNGChunkWriter':
         return self
 
-    def __exit__(self, _a, _b, _c):
+    def __exit__(self,
+                 _a: Optional[BaseException],
+                 _b: Optional[str],
+                 _c: Optional[TracebackType]) -> None:
         end_of_block = self.stream.tell()
         block_length = end_of_block - self.start_of_block
         data_length = block_length - 4
         self.stream.write(struct.pack(">L", self.crc))
         self.length_placeholder.commit(data_length)
 
-    def write(self, data):
+    def write(self, data: bytes) -> None:
         self.crc = zlib.crc32(data, self.crc)
         self.stream.write(data)
 
-def pack_png(bgra_image, width, height):
+def pack_png(bgra_image: bytes, width: int, height: int) -> bytes:
     png = io.BytesIO()
     png.write(b"\x89PNG\r\n\x1A\n")
 

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -32,7 +32,7 @@ class StructConverter(ResourceConverter):
         self.is_list = is_list
 
     def convert(self, res: Resource,
-                res_map: Dict[bytes, Dict[int, Resource]]) -> Union[List[Dict[str, bytes]], Dict[str, bytes]]:
+                res_map: dict[bytes, dict[int, Resource]]) -> list[dict[str, bytes]] | dict[str, bytes]:
         if self.is_list:
             res_object = []
             assert len(res.data) % self.record_length == 0

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -50,7 +50,6 @@ class StructConverter(ResourceConverter):
         return record
 
 class SingleStringConverter(ResourceConverter):
-    __slots__: Tuple = tuple()
     def convert(self, res: Resource,
                 res_map: dict[bytes, dict[int, Resource]]) -> bytes:
         result = Unpacker(res.data).unpack_pstr()

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -82,7 +82,6 @@ class IcnsConverter(ResourceConverter):
         return res.data
 
 class SoundToAiffConverter(ResourceConverter):
-    __slots__: Tuple = tuple()
     def __init__(self) -> None:
         super().__init__(separate_file='.aiff')
 

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -176,7 +176,6 @@ class IconConverter(ResourceConverter):
         else:
             print(F"[WARNING] No {bw_icon_type.decode('macroman')} mask for {res.type.decode('macroman')} #{res.num}")
             bw_icon = b''
-##            bw_mask = None
             bw_mask = b''
 
         if res.type in [b'icl8', b'ics8']:

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import Any, Callable
 
 import struct
 

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -48,7 +48,7 @@ class StructConverter(ResourceConverter):
 class SingleStringConverter(ResourceConverter):
     __slots__: Tuple = tuple()
     def convert(self, res: Resource,
-                res_map: Dict[bytes, Dict[int, Resource]]) -> bytes:
+                res_map: dict[bytes, dict[int, Resource]]) -> bytes:
         result = Unpacker(res.data).unpack_pstr()
         assert not isinstance(result, str), 'This should be impossible'
         return result

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -15,7 +15,7 @@ class ResourceConverter:
     def __init__(self, separate_file: str="") -> None:
         self.separate_file = separate_file
 
-    def convert(self, res: Resource, res_map: Dict[bytes, Dict[int, Resource]]) -> Any:
+    def convert(self, res: Resource, res_map: dict[bytes, dict[int, Resource]]) -> Any:
         return res.data
 
 class StructConverter(ResourceConverter):

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -127,7 +127,7 @@ class SicnConverter(ResourceConverter):
 
 class TemplateConverter(ResourceConverter):
     def convert(self, res: Resource,
-                res_map: Dict[bytes, Dict[int, Resource]]) -> List[Dict[str, Union[str, bytes]]]:
+                res_map: dict[bytes, dict[int, Resource]]) -> list[dict[str, str]]:
         u = Unpacker(res.data)
         fields = []
         while not u.eof():

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -108,7 +108,6 @@ class CicnConverter(ResourceConverter):
         return pack_png(data, w, h)
 
 class PpatConverter(ResourceConverter):
-    __slots__: Tuple = tuple()
     def __init__(self) -> None:
         super().__init__(separate_file='.png')
 

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -78,7 +78,7 @@ class IcnsConverter(ResourceConverter):
         super().__init__(separate_file='.icns')
 
     def convert(self, res: Resource,
-                res_map: Dict[bytes, Dict[int, Resource]]) -> bytes:
+                res_map: dict[bytes, dict[int, Resource]]) -> bytes:
         return res.data
 
 class SoundToAiffConverter(ResourceConverter):

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -154,7 +154,7 @@ class IconConverter(ResourceConverter):
         super().__init__(separate_file='.png')
     
     def convert(self, res: Resource,
-                res_map: Dict[bytes, Dict[int, Resource]]) -> bytes:
+                res_map: dict[bytes, dict[int, Resource]]) -> bytes:
         if res.type in [b'icl8', b'icl4', b'ICN#']:
             width, height = 32, 32
             bw_icon_type = b'ICN#'

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -127,7 +127,7 @@ class SicnConverter(ResourceConverter):
 
 class TemplateConverter(ResourceConverter):
     def convert(self, res: Resource,
-                res_map: dict[bytes, dict[int, Resource]]) -> list[dict[str, str]]:
+                res_map: dict[bytes, dict[int, Resource]]) -> list[dict[str, str | bytes]]:
         u = Unpacker(res.data)
         fields = []
         while not u.eof():

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -99,7 +99,6 @@ class PictConverter(ResourceConverter):
         return pack_png(data, w, h)
 
 class CicnConverter(ResourceConverter):
-    __slots__: Tuple = tuple()
     def __init__(self) -> None:
         super().__init__(separate_file='.png')
 

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -126,7 +126,6 @@ class SicnConverter(ResourceConverter):
         return pack_png(data, w, h)
 
 class TemplateConverter(ResourceConverter):
-    __slots__: Tuple = tuple()
     def convert(self, res: Resource,
                 res_map: Dict[bytes, Dict[int, Resource]]) -> List[Dict[str, Union[str, bytes]]]:
         u = Unpacker(res.data)

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -74,7 +74,6 @@ class TextConverter(ResourceConverter):
         return res.data.decode("macroman")
 
 class IcnsConverter(ResourceConverter):
-    __slots__: Tuple = tuple()
     def __init__(self) -> None:
         super().__init__(separate_file='.icns')
 

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -117,7 +117,6 @@ class PpatConverter(ResourceConverter):
         return pack_png(data, w, h)
 
 class SicnConverter(ResourceConverter):
-    __slots__: Tuple = tuple()
     def __init__(self) -> None:
         super().__init__(separate_file='.png')
 

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -69,7 +69,6 @@ class StringListConverter(ResourceConverter):
         return str_list
 
 class TextConverter(ResourceConverter):
-    __slots__: Tuple = tuple()
     def convert(self, res: Resource,
                 res_map: dict[bytes, dict[int, Resource]]) -> str:
         return res.data.decode("macroman")

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -94,7 +94,7 @@ class PictConverter(ResourceConverter):
         super().__init__(separate_file='.png')
 
     def convert(self, res: Resource,
-                res_map: Dict[bytes, Dict[int, Resource]]) -> bytes:
+                res_map: dict[bytes, dict[int, Resource]]) -> bytes:
         w, h, data = convert_pict_to_image(res.data)
         return pack_png(data, w, h)
 

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -112,7 +112,7 @@ class PpatConverter(ResourceConverter):
         super().__init__(separate_file='.png')
 
     def convert(self, res: Resource,
-                res_map: Dict[bytes, Dict[int, Resource]]) -> bytes:
+                res_map: dict[bytes, dict[int, Resource]]) -> bytes:
         w, h, data = convert_ppat_to_image(res.data)
         return pack_png(data, w, h)
 

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -90,7 +90,6 @@ class SoundToAiffConverter(ResourceConverter):
         return convert_snd_to_aiff(res.data, res.name)
 
 class PictConverter(ResourceConverter):
-    __slots__: Tuple = tuple()
     def __init__(self) -> None:
         super().__init__(separate_file='.png')
 

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -143,7 +143,7 @@ class FileDumper(ResourceConverter):
         super().__init__(extension)
         self.preprocess = preprocess
 
-    def convert(self, res: Resource, res_map: Dict[bytes, Dict[int, Resource]]) -> bytes:
+    def convert(self, res: Resource, res_map: dict[bytes, dict[int, Resource]]) -> bytes:
         if self.preprocess:
             return self.preprocess(res.data)
         else:

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -103,7 +103,7 @@ class CicnConverter(ResourceConverter):
         super().__init__(separate_file='.png')
 
     def convert(self, res: Resource,
-                res_map: Dict[bytes, Dict[int, Resource]]) -> bytes:
+                res_map: dict[bytes, dict[int, Resource]]) -> bytes:
         w, h, data = convert_cicn_to_image(res.data)
         return pack_png(data, w, h)
 

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -57,7 +57,6 @@ class SingleStringConverter(ResourceConverter):
         return result
 
 class StringListConverter(ResourceConverter):
-    __slots__: Tuple = tuple()
     def convert(self, res: Resource,
                 res_map: Dict[bytes, Dict[int, Resource]]) -> List[bytes]:
         u = Unpacker(res.data)

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -173,7 +173,6 @@ class IconConverter(ResourceConverter):
             bw_mask = b''
 
         if res.type in [b'icl8', b'ics8']:
-            
             image = convert_8bit_icon_to_bgra(color_icon, bw_mask, width, height)
         elif res.type in [b'icl4', b'ics4']:
             image = convert_4bit_icon_to_bgra(color_icon, bw_mask, width, height)

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -121,7 +121,7 @@ class SicnConverter(ResourceConverter):
         super().__init__(separate_file='.png')
 
     def convert(self, res: Resource,
-                res_map: Dict[bytes, Dict[int, Resource]]) -> bytes:
+                res_map: dict[bytes, dict[int, Resource]]) -> bytes:
         w, h, data = convert_sicn_to_image(res.data)
         return pack_png(data, w, h)
 

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -58,7 +58,7 @@ class SingleStringConverter(ResourceConverter):
 
 class StringListConverter(ResourceConverter):
     def convert(self, res: Resource,
-                res_map: Dict[bytes, Dict[int, Resource]]) -> List[bytes]:
+                res_map: dict[bytes, dict[int, Resource]]) -> list[bytes]:
         u = Unpacker(res.data)
         str_list = []
         count, = u.unpack(">H")

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -10,8 +10,9 @@ from rsrcdump.icons import convert_4bit_icon_to_bgra, convert_8bit_icon_to_bgra,
 from rsrcdump.resfork import Resource
 
 class ResourceConverter:
-    __slots__ = ('separate_file',)
-    def __init__(self, separate_file: str=None) -> None:
+    separate_file: str
+
+    def __init__(self, separate_file: str="") -> None:
         self.separate_file = separate_file
 
     def convert(self, res: Resource, res_map: Dict[bytes, Dict[int, Resource]]) -> Any:

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -137,7 +137,8 @@ class TemplateConverter(ResourceConverter):
         return fields
 
 class FileDumper(ResourceConverter):
-    __slots__ = ('preprocess',)
+    preprocess: Callable[[bytes], bytes] | None
+
     def __init__(self, extension: str, preprocess: Callable[[bytes], bytes]=None) -> None:
         super().__init__(extension)
         self.preprocess = preprocess

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -150,7 +150,6 @@ class FileDumper(ResourceConverter):
             return res.data
 
 class IconConverter(ResourceConverter):
-    __slots__: Tuple = tuple()
     def __init__(self) -> None:
         super().__init__(separate_file='.png')
     

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -41,7 +41,7 @@ class StructConverter(ResourceConverter):
             return res_object
         return self.parse_record(res.data, 0)
 
-    def parse_record(self, data: bytes, offset: int) -> Dict[str, bytes]:
+    def parse_record(self, data: bytes, offset: int) -> dict[str, bytes]:
         record = {}
         field_values = struct.unpack_from(self.fmt, data, offset)
         for field_name, field_val in zip(self.field_names, field_values):

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -175,7 +175,7 @@ class IconConverter(ResourceConverter):
             bw_mask = bw_icon[width*height//8:]
         else:
             print(F"[WARNING] No {bw_icon_type.decode('macroman')} mask for {res.type.decode('macroman')} #{res.num}")
-            bw_icon = None
+            bw_icon = b''
 ##            bw_mask = None
             bw_mask = b''
 

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -86,7 +86,7 @@ class SoundToAiffConverter(ResourceConverter):
         super().__init__(separate_file='.aiff')
 
     def convert(self, res: Resource,
-                res_map: Dict[bytes, Dict[int, Resource]]) -> bytes:
+                res_map: dict[bytes, dict[int, Resource]]) -> bytes:
         return convert_snd_to_aiff(res.data, res.name)
 
 class PictConverter(ResourceConverter):

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -19,7 +19,11 @@ class ResourceConverter:
         return res.data
 
 class StructConverter(ResourceConverter):
-    __slots__ = ('fmt', 'record_length', 'field_names', 'is_list')
+    fmt: str
+    record_length: int
+    field_names: list[str]
+    is_list: bool
+
     def __init__(self, fmt: str, field_name_str: str, is_list: bool=False) -> None:
         super().__init__()
         self.fmt = fmt

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -69,7 +69,7 @@ class StringListConverter(ResourceConverter):
 class TextConverter(ResourceConverter):
     __slots__: Tuple = tuple()
     def convert(self, res: Resource,
-                res_map: Dict[bytes, Dict[int, Resource]]) -> str:
+                res_map: dict[bytes, dict[int, Resource]]) -> str:
         return res.data.decode("macroman")
 
 class IcnsConverter(ResourceConverter):

--- a/rsrcdump/resconverters.py
+++ b/rsrcdump/resconverters.py
@@ -1,36 +1,42 @@
+from typing import Any, Callable, Dict, List, Tuple, Union
+
 import struct
+
 from rsrcdump.packutils import Unpacker
 from rsrcdump.pict import convert_pict_to_image, convert_cicn_to_image, convert_ppat_to_image, convert_sicn_to_image
 from rsrcdump.png import pack_png
 from rsrcdump.sndtoaiff import convert_snd_to_aiff
 from rsrcdump.icons import convert_4bit_icon_to_bgra, convert_8bit_icon_to_bgra, convert_1bit_icon_to_bgra
+from rsrcdump.resfork import Resource
 
 class ResourceConverter:
-    def __init__(self, separate_file=None):
+    __slots__ = ('separate_file',)
+    def __init__(self, separate_file: str=None) -> None:
         self.separate_file = separate_file
 
-    def convert(self, res, res_map):
+    def convert(self, res: Resource, res_map: Dict[bytes, Dict[int, Resource]]) -> Any:
         return res.data
 
 class StructConverter(ResourceConverter):
-    def __init__(self, fmt, field_name_str, is_list=False):
+    __slots__ = ('fmt', 'record_length', 'field_names', 'is_list')
+    def __init__(self, fmt: str, field_name_str: str, is_list: bool=False) -> None:
         super().__init__()
         self.fmt = fmt
         self.record_length = struct.calcsize(fmt)
         self.field_names = field_name_str.split(",")
         self.is_list = is_list
 
-    def convert(self, res, res_map):
+    def convert(self, res: Resource,
+                res_map: Dict[bytes, Dict[int, Resource]]) -> Union[List[Dict[str, bytes]], Dict[str, bytes]]:
         if self.is_list:
             res_object = []
             assert len(res.data) % self.record_length == 0
             for i in range(len(res.data) // self.record_length):
                 res_object.append(self.parse_record(res.data, i*self.record_length))
             return res_object
-        else:
-            return self.parse_record(res.data, 0)
+        return self.parse_record(res.data, 0)
 
-    def parse_record(self, data, offset):
+    def parse_record(self, data: bytes, offset: int) -> Dict[str, bytes]:
         record = {}
         field_values = struct.unpack_from(self.fmt, data, offset)
         for field_name, field_val in zip(self.field_names, field_values):
@@ -39,70 +45,94 @@ class StructConverter(ResourceConverter):
         return record
 
 class SingleStringConverter(ResourceConverter):
-    def convert(self, res, res_map):
-        return Unpacker(res.data).unpack_pstr()
+    __slots__: Tuple = tuple()
+    def convert(self, res: Resource,
+                res_map: Dict[bytes, Dict[int, Resource]]) -> bytes:
+        result = Unpacker(res.data).unpack_pstr()
+        assert not isinstance(result, str), 'This should be impossible'
+        return result
 
 class StringListConverter(ResourceConverter):
-    def convert(self, res, res_map):
+    __slots__: Tuple = tuple()
+    def convert(self, res: Resource,
+                res_map: Dict[bytes, Dict[int, Resource]]) -> List[bytes]:
         u = Unpacker(res.data)
         str_list = []
         count, = u.unpack(">H")
         for i in range(count):
-            str_list.append(u.unpack_pstr())
+            value = u.unpack_pstr()
+            assert not isinstance(value, str), 'This should be impossible'
+            str_list.append(value)
         return str_list
 
 class TextConverter(ResourceConverter):
-    def convert(self, res, res_map):
+    __slots__: Tuple = tuple()
+    def convert(self, res: Resource,
+                res_map: Dict[bytes, Dict[int, Resource]]) -> str:
         return res.data.decode("macroman")
 
 class IcnsConverter(ResourceConverter):
-    def __init__(self):
+    __slots__: Tuple = tuple()
+    def __init__(self) -> None:
         super().__init__(separate_file='.icns')
 
-    def convert(self, res, res_map):
+    def convert(self, res: Resource,
+                res_map: Dict[bytes, Dict[int, Resource]]) -> bytes:
         return res.data
 
 class SoundToAiffConverter(ResourceConverter):
-    def __init__(self):
+    __slots__: Tuple = tuple()
+    def __init__(self) -> None:
         super().__init__(separate_file='.aiff')
 
-    def convert(self, res, res_map):
+    def convert(self, res: Resource,
+                res_map: Dict[bytes, Dict[int, Resource]]) -> bytes:
         return convert_snd_to_aiff(res.data, res.name)
 
 class PictConverter(ResourceConverter):
-    def __init__(self):
+    __slots__: Tuple = tuple()
+    def __init__(self) -> None:
         super().__init__(separate_file='.png')
 
-    def convert(self, res, res_map):
+    def convert(self, res: Resource,
+                res_map: Dict[bytes, Dict[int, Resource]]) -> bytes:
         w, h, data = convert_pict_to_image(res.data)
         return pack_png(data, w, h)
 
 class CicnConverter(ResourceConverter):
-    def __init__(self):
+    __slots__: Tuple = tuple()
+    def __init__(self) -> None:
         super().__init__(separate_file='.png')
 
-    def convert(self, res, res_map):
+    def convert(self, res: Resource,
+                res_map: Dict[bytes, Dict[int, Resource]]) -> bytes:
         w, h, data = convert_cicn_to_image(res.data)
         return pack_png(data, w, h)
 
 class PpatConverter(ResourceConverter):
-    def __init__(self):
+    __slots__: Tuple = tuple()
+    def __init__(self) -> None:
         super().__init__(separate_file='.png')
 
-    def convert(self, res, res_map):
+    def convert(self, res: Resource,
+                res_map: Dict[bytes, Dict[int, Resource]]) -> bytes:
         w, h, data = convert_ppat_to_image(res.data)
         return pack_png(data, w, h)
 
 class SicnConverter(ResourceConverter):
-    def __init__(self):
+    __slots__: Tuple = tuple()
+    def __init__(self) -> None:
         super().__init__(separate_file='.png')
 
-    def convert(self, res, res_map):
+    def convert(self, res: Resource,
+                res_map: Dict[bytes, Dict[int, Resource]]) -> bytes:
         w, h, data = convert_sicn_to_image(res.data)
         return pack_png(data, w, h)
 
 class TemplateConverter(ResourceConverter):
-    def convert(self, res, res_map):
+    __slots__: Tuple = tuple()
+    def convert(self, res: Resource,
+                res_map: Dict[bytes, Dict[int, Resource]]) -> List[Dict[str, Union[str, bytes]]]:
         u = Unpacker(res.data)
         fields = []
         while not u.eof():
@@ -112,21 +142,24 @@ class TemplateConverter(ResourceConverter):
         return fields
 
 class FileDumper(ResourceConverter):
-    def __init__(self, extension, preprocess=None):
+    __slots__ = ('preprocess',)
+    def __init__(self, extension: str, preprocess: Callable[[bytes], bytes]=None) -> None:
         super().__init__(extension)
         self.preprocess = preprocess
 
-    def convert(self, res, res_map):
+    def convert(self, res: Resource, res_map: Dict[bytes, Dict[int, Resource]]) -> bytes:
         if self.preprocess:
             return self.preprocess(res.data)
         else:
             return res.data
 
 class IconConverter(ResourceConverter):
-    def __init__(self):
+    __slots__: Tuple = tuple()
+    def __init__(self) -> None:
         super().__init__(separate_file='.png')
     
-    def convert(self, res, res_map):
+    def convert(self, res: Resource,
+                res_map: Dict[bytes, Dict[int, Resource]]) -> bytes:
         if res.type in [b'icl8', b'icl4', b'ICN#']:
             width, height = 32, 32
             bw_icon_type = b'ICN#'
@@ -142,9 +175,11 @@ class IconConverter(ResourceConverter):
         else:
             print(F"[WARNING] No {bw_icon_type.decode('macroman')} mask for {res.type.decode('macroman')} #{res.num}")
             bw_icon = None
-            bw_mask = None
+##            bw_mask = None
+            bw_mask = b''
 
         if res.type in [b'icl8', b'ics8']:
+            
             image = convert_8bit_icon_to_bgra(color_icon, bw_mask, width, height)
         elif res.type in [b'icl4', b'ics4']:
             image = convert_4bit_icon_to_bgra(color_icon, bw_mask, width, height)

--- a/rsrcdump/resfork.py
+++ b/rsrcdump/resfork.py
@@ -25,7 +25,7 @@ def unpack_resfork(fork: bytes) -> dict[bytes, dict[int, Resource]]:
     file_attributes, typelist_offset_in_map, namelist_offset_in_map, num_types = u_map.unpack(">16x4x2xHHHH")
     num_types += 1
 
-    res_map: Dict[bytes, Dict[int, Resource]] = {}
+    res_map: dict[bytes, dict[int, Resource]] = {}
 
     u_types = Unpacker(u_map.data[typelist_offset_in_map:])
     u_names = Unpacker(u_map.data[namelist_offset_in_map:])

--- a/rsrcdump/resfork.py
+++ b/rsrcdump/resfork.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from dataclasses import dataclass
 from struct import unpack_from, pack
 from io import BytesIO

--- a/rsrcdump/resfork.py
+++ b/rsrcdump/resfork.py
@@ -12,7 +12,7 @@ class Resource:
     name: bytes
     flags: int  # byte
 
-def unpack_resfork(fork: bytes) -> Dict[bytes, Dict[int, Resource]]:
+def unpack_resfork(fork: bytes) -> dict[bytes, dict[int, Resource]]:
     if not fork:
         return {}
 

--- a/rsrcdump/resfork.py
+++ b/rsrcdump/resfork.py
@@ -66,7 +66,7 @@ def unpack_resfork(fork: bytes) -> dict[bytes, dict[int, Resource]]:
 
     return res_map
 
-def pack_resfork(res_map: Dict[bytes, Dict[str, Resource]]) -> bytes:
+def pack_resfork(res_map: dict[bytes, dict[str, Resource]]) -> bytes:
     stream = BytesIO()
 
     # Resource fork

--- a/rsrcdump/resfork.py
+++ b/rsrcdump/resfork.py
@@ -1,7 +1,10 @@
+from typing import Dict
+
 from dataclasses import dataclass
-from rsrcdump.packutils import Unpacker, WritePlaceholder
 from struct import unpack_from, pack
 from io import BytesIO
+
+from rsrcdump.packutils import Unpacker, WritePlaceholder
 
 @dataclass
 class Resource:
@@ -11,7 +14,7 @@ class Resource:
     name: bytes
     flags: int  # byte
 
-def unpack_resfork(fork):
+def unpack_resfork(fork: bytes) -> Dict[bytes, Dict[int, Resource]]:
     if not fork:
         return {}
 
@@ -24,7 +27,7 @@ def unpack_resfork(fork):
     file_attributes, typelist_offset_in_map, namelist_offset_in_map, num_types = u_map.unpack(">16x4x2xHHHH")
     num_types += 1
 
-    res_map = {}
+    res_map: Dict[bytes, Dict[int, Resource]] = {}
 
     u_types = Unpacker(u_map.data[typelist_offset_in_map:])
     u_names = Unpacker(u_map.data[namelist_offset_in_map:])
@@ -65,7 +68,7 @@ def unpack_resfork(fork):
 
     return res_map
 
-def pack_resfork(res_map):
+def pack_resfork(res_map: Dict[bytes, Dict[str, Resource]]) -> bytes:
     stream = BytesIO()
 
     # Resource fork

--- a/rsrcdump/textio.py
+++ b/rsrcdump/textio.py
@@ -12,7 +12,7 @@ def parse_type_name(sane_name: str) -> bytes:
     assert len(ostype) == 4
     return ostype
 
-def sanitize_resource_name(name):
+def sanitize_resource_name(name: str) -> str:
     sanitized = ""
     for c in name:
         if c in 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-':

--- a/rsrcdump/tga.py
+++ b/rsrcdump/tga.py
@@ -1,7 +1,7 @@
 from io import BytesIO
 import struct
 
-def pack_tga(bgra_image, width, height):
+def pack_tga(bgra_image: bytes, width: int, height: int) -> bytes:
     assert len(bgra_image) == 4*width*height
     tga = BytesIO()
     tga.write(struct.pack("<BBBHHBHHHHBB",


### PR DESCRIPTION
This pull request aims to add type annotations to everything.
Other than type annotations, removes one unneeded F string, changes a few unused count variables to `_`, adds a few type assertions so my type checker doesn't get mad, makes rsrcdump/packutils.py `Unpacker` init argument `offset` actually do something, changes things like
```python
def func(say: str, is_cat: bool=False) -> str:
    if is_cat:
        return f'Cat says: {say}'
    else:
        return f'Person says: {say}'
```
to
```python
def func(say: str, is_cat: bool=False) -> str:
    if is_cat:
        return f'Cat says: {say}'
    return f'Person says: {say}'
```
, and changes
```python
...
with open(outpath + "/index.json", 'w') as file:
...
```
to
```python
...
with open(outpath + "/index.json", 'w', encoding='utf-8') as file:
...
```